### PR TITLE
Assorted improvements to xgboost-ruby

### DIFF
--- a/bin/install_xgboost.sh
+++ b/bin/install_xgboost.sh
@@ -8,12 +8,18 @@ mkdir -p "$target"
 target=$(cd "$target"; pwd -P)
 cd "$target"
 
-if [ ! -d ".git" ]; then
-  git clone --recursive --jobs 4 --depth 1 https://github.com/dmlc/xgboost .
+if [ ! -d .git ]; then
+  git clone --recurse-submodules --jobs 4 https://github.com/dmlc/xgboost .
+else
+  git fetch --recurse-submodules --jobs 4
 fi
 
-git pull
-git submodule update --remote
+if [[ -z "$1" ]]; then
+  git checkout origin/master
+  git submodule update --remote
+else
+  git checkout "$1"
+fi
 
 if [[ "$OSTYPE" == darwin* ]]; then
   cp make/minimum.mk config.mk

--- a/bin/install_xgboost.sh
+++ b/bin/install_xgboost.sh
@@ -9,9 +9,9 @@ target=$(cd "$target"; pwd -P)
 cd "$target"
 
 if [ ! -d .git ]; then
-  git clone --recurse-submodules --jobs 4 https://github.com/dmlc/xgboost .
+  git clone --recurse-submodules https://github.com/dmlc/xgboost .
 else
-  git fetch --recurse-submodules --jobs 4
+  git fetch --recurse-submodules
 fi
 
 if [[ -z "$1" ]]; then

--- a/lib/xgboost/booster.rb
+++ b/lib/xgboost/booster.rb
@@ -27,7 +27,7 @@ module Xgboost
       FFI.XGBoosterFree(handle_pointer)
     end
 
-    def predict(input)
+    def predict(input, missing: Float::NAN)
       raise TypeError unless input.is_a?(Array)
 
       unless input_2d = input.first.is_a?(Array)
@@ -41,7 +41,7 @@ module Xgboost
       data.put_array_of_float(0, input.flatten)
 
       dmatrix = ::FFI::MemoryPointer.new(:pointer)
-      FFI.XGDMatrixCreateFromMat(data, input.count, input.first.count, 0, dmatrix)
+      FFI.XGDMatrixCreateFromMat(data, input.count, input.first.count, missing, dmatrix)
 
       FFI.XGBoosterPredict(handle_pointer, dmatrix.read_pointer, 0, 0, out_len, out_result)
 

--- a/lib/xgboost/rake.rb
+++ b/lib/xgboost/rake.rb
@@ -8,8 +8,8 @@ module Xgboost
     def self.add_tasks
       namespace :xgboost do
         desc 'Clones and compiles xgboost'
-        task :install do
-          `#{Xgboost.root}/bin/install_xgboost.sh`
+        task :install, :sha do |_t, args|
+          system(File.join(Xgboost.root, 'bin', 'install_xgboost.sh'), args[:sha])
         end
       end
     end

--- a/spec/xgboost/booster_spec.rb
+++ b/spec/xgboost/booster_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Xgboost::Booster do
         expect(booster.predict([1.0])).to be_within(0.00001).of(2.06937)
       end
 
+      it 'allows passing the value of missing as an arg' do
+        expect(booster.predict([2.0], missing: Float::NAN)).to be_within(0.00001).of(4.03468)
+        expect(booster.predict([1.0], missing: Float::NAN)).to be_within(0.00001).of(2.06937)
+      end
+
       it 'raises an error when given invalid arguments' do
         expect { booster.predict(2.0) }.to raise_error(TypeError)
         expect { booster.predict(nil) }.to raise_error(TypeError)


### PR DESCRIPTION
I've been trying to use xgboost-ruby and stumbled upon a few things that needed to be changed for my particular use case.

Opening a PR here in case some of these changes make sense for the project as a whole.

Changes:
* Allow passing a `missing` arg to `booster#predict`
The current default value for missing, 0, might be a legitimate value
for a feature in a dataset.
Allowing passing a missing provides some flexibility while users can't
create their own dmatrix input.

* Allow passing a SHA to install_xgboost
This allows users to install a specific stable version of
xgboost.

* Remove --jobs option from git clone
Some git versions don't have a --jobs option leading this to command to lead to an error in those environments.

* Prevent memory leak in `Xgboost::Booster`